### PR TITLE
Speedup and improve chown en chmod

### DIFF
--- a/app-hooks/before-starting/setup-files-permission.sh
+++ b/app-hooks/before-starting/setup-files-permission.sh
@@ -2,6 +2,11 @@
 set -eu
 
 if [ "$(id -u)" = 0 ]; then
-    chown -R www-data:root /var/www/html
-    chmod 750 www-data:root /var/www/html/data
+    # chown -R www-data:root /var/www/html
+    (
+        ( find /var/www/html  -not -group root -not -user www-data -print0 | xargs -P 0 -0 --no-run-if-empty chown --no-dereference www-data:root ) ; \
+    # chmod 750 www-data:root /var/www/html/data
+        ( find /var/www/html/data -type d -not -perm 750 -print0 | xargs -P 0 -0 --no-run-if-empty chmod 750 ) ; \
+        ( find /var/www/html/data -type f -not -perm 650 -print0 | xargs -P 0 -0 --no-run-if-empty chmod 650 )
+    ) &
 fi


### PR DESCRIPTION
This speeds up chown and chmod plus sets 750 for directories only and 640 for files.

Plus it runs it non-blocking and allows nextcloud to startup at the same time.  Looking at the Dockerfile for Nextcloud,  hooks are not used yet?